### PR TITLE
Prevent startTest() from raising TypeError when test.address() contai…

### DIFF
--- a/nose_allure/__init__.py
+++ b/nose_allure/__init__.py
@@ -102,7 +102,7 @@ class Allure(Plugin):
         else:
             method = getattr(test.test, test.test._testMethodName)
 
-        hierarchy = ".".join(test.address()[1:])
+        hierarchy = ".".join([filter(None, test.address()[1:]))
 
         self.allure.impl.start_case(hierarchy, description=method.__doc__,
                                     labels=get_labels(method))


### PR DESCRIPTION
…ns None

If a test case fails during the class setup, nose_allure gives a very confusing error mesage:

```
Traceback (most recent call last):
  File "/box/python/lib/python2.7/site-packages/nose/case.py", line 133, in run
    self.runTest(result)
  File "/box/python/lib/python2.7/site-packages/nose/case.py", line 151, in runTest
    test(result)
  File "/box/python/lib/python2.7/unittest/case.py", line 393, in __call__
    return self.run(*args, **kwds)
  File "/box/python/lib/python2.7/unittest/case.py", line 304, in run
    result.startTest(self)
  File "/box/python/lib/python2.7/site-packages/nose/proxy.py", line 169, in startTest
    self.plugins.startTest(self.test)
  File "/box/python/lib/python2.7/site-packages/nose/plugins/manager.py", line 99, in __call__
    return self.call(*arg, **kw)
  File "/box/python/lib/python2.7/site-packages/nose/plugins/manager.py", line 167, in simple
    result = meth(*arg, **kw)
  File "/box/python/lib/python2.7/site-packages/nose_allure/__init__.py", line 113, in startTest
    hierarchy = ".".join(test.address()[1:])
TypeError: sequence item 1: expected string, NoneType found
```

If we filter out `None`s from test.address() then we can avoid this error sanely, and we end up getting a much better error message telling us what went wrong in our own code initially.
